### PR TITLE
Parents

### DIFF
--- a/src/napari_sediment/rgb_widget.py
+++ b/src/napari_sediment/rgb_widget.py
@@ -18,12 +18,12 @@ class RGBWidget(QWidget):
     - an attribute called row_bounds and col_bounds, which are the current crop
     bounds."""
 
-    def __init__(self, parent):
-        super().__init__(parent)
+    def __init__(self, viewer, imagechannels=None):
+        super().__init__()
 
-        self.parent = parent
-        self.viewer = parent.viewer
-        self.rgb =self.parent.params.rgb
+        self.viewer = viewer
+        self.imagechannels = imagechannels
+        self.rgb = [640, 545, 460]
 
         self.rgbmain_group = VHGroup('RGB', orientation='G')
         #self.tabs.add_named_tab('Main', self.rgbmain_group.gbox)
@@ -89,8 +89,13 @@ class RGBWidget(QWidget):
     def _on_change_rgb(self, event=None):
 
         self.rgb = [self.spin_rchannel.value(), self.spin_gchannel.value(), self.spin_bchannel.value()]
-        self.parent.params.rgb = self.rgb
     
+    def set_rgb(self, rgb):
+            
+        self.spin_rchannel.setValue(rgb[0])
+        self.spin_gchannel.setValue(rgb[1])
+        self.spin_bchannel.setValue(rgb[2])
+
     def _set_rgb_default(self):
 
         self.spin_rchannel.setValue(640)
@@ -100,8 +105,8 @@ class RGBWidget(QWidget):
     def _on_click_RGB(self, event=None):
         """Load RGB image"""
 
-        self.rgb_ch, self.rgb_names = self.parent.imagechannels.get_indices_of_bands(self.rgb)
-        rgb_cube = self.parent.imagechannels.get_image_cube(self.rgb_ch)
+        self.rgb_ch, self.rgb_names = self.imagechannels.get_indices_of_bands(self.rgb)
+        rgb_cube = self.imagechannels.get_image_cube(self.rgb_ch)
         self.add_rgb_cube_to_viewer(rgb_cube)
 
     def get_current_rgb_cube(self):
@@ -132,8 +137,8 @@ class RGBWidget(QWidget):
 
     def load_and_display_rgb_bands(self, roi=None):
 
-        self.rgb_ch, self.rgb_names = self.parent.imagechannels.get_indices_of_bands(self.rgb)
-        rgb_cube = self.parent.imagechannels.get_image_cube(self.rgb_ch, roi=roi)
+        self.rgb_ch, self.rgb_names = self.imagechannels.get_indices_of_bands(self.rgb)
+        rgb_cube = self.imagechannels.get_image_cube(self.rgb_ch, roi=roi)
         
         self.add_rgb_cube_to_viewer(rgb_cube)
 
@@ -158,7 +163,7 @@ class RGBWidget(QWidget):
                     colormap=cmap,
                     blending='additive')
             else:
-                self.parent.viewer.layers[cmap].data = rgb_cube[ind]
+                self.viewer.layers[cmap].data = rgb_cube[ind]
             
             self.viewer.layers[cmap].contrast_limits_range = (self.viewer.layers[cmap].data.min(), self.viewer.layers[cmap].data.max())
             self.viewer.layers[cmap].contrast_limits = np.percentile(self.viewer.layers[cmap].data, (2,98))

--- a/src/napari_sediment/spectral_indices_widget.py
+++ b/src/napari_sediment/spectral_indices_widget.py
@@ -97,10 +97,11 @@ class SpectralIndexWidget(QWidget):
         self.tabs.add_named_tab('&Main', self.export_path_display)
         self.btn_load_project = QPushButton("Load project")
         self.tabs.add_named_tab('&Main', self.btn_load_project)
-        self.qlist_channels = ChannelWidget(self)
+        self.qlist_channels = ChannelWidget(self.viewer)
+        self.qlist_channels.itemClicked.connect(self._on_change_select_bands)
         self.tabs.add_named_tab('&Main', self.qlist_channels)
 
-        self.rgbwidget = RGBWidget(self)
+        self.rgbwidget = RGBWidget(viewer=self.viewer)
         self.tabs.add_named_tab('&Main', self.rgbwidget.rgbmain_group.gbox)
 
         # indices tab
@@ -366,7 +367,8 @@ class SpectralIndexWidget(QWidget):
         self.col_bounds = [self.mainroi[0][:,1].min(), self.mainroi[0][:,1].max()]
         
         self.imagechannels = ImChannels(self.export_folder.joinpath('corrected.zarr'))
-        self.qlist_channels._update_channel_list()
+        self.qlist_channels._update_channel_list(imagechannels=self.imagechannels)
+        self.rgbwidget.imagechannels = self.imagechannels
 
         self.get_RGB()
         self.rgbwidget.load_and_display_rgb_bands(roi=np.concatenate([self.row_bounds, self.col_bounds]))
@@ -416,7 +418,11 @@ class SpectralIndexWidget(QWidget):
         
         rgb_ch, rgb_names = self.imagechannels.get_indices_of_bands(self.rgbwidget.rgb)
         [self.qlist_channels.item(x).setSelected(True) for x in rgb_ch]
-        self.qlist_channels._on_change_channel_selection()
+        self.qlist_channels._on_change_channel_selection(self.row_bounds, self.col_bounds)
+
+    def _on_change_select_bands(self, event=None):
+
+        self.qlist_channels._on_change_channel_selection(self.row_bounds, self.col_bounds)
 
     def plot_endmembers(self, event=None):
         """Cluster the pure pixels and plot the endmembers as average of clusters."""

--- a/src/napari_sediment/spectral_indices_widget.py
+++ b/src/napari_sediment/spectral_indices_widget.py
@@ -487,7 +487,7 @@ class SpectralIndexWidget(QWidget):
         self.params_plots.color_plotline = [self.qcolor_plotline.currentColor().getRgb()[x]/255 for x in range(3)]
         self.params_plots.plot_thickness = self.spin_plot_thickness.value()
         self.params_plots.title_font_factor = self.spin_title_font_factor.value()
-        self.params_plots.label_font_factor = self.spin_title_font_factor.value()
+        self.params_plots.label_font_factor = self.spin_label_font_factor.value()
         self.params_plots.scale_font_size = self.spin_scale_font_size.value()
         self.params_plots.left_right_margin_fraction = self.spin_left_right_margin_fraction.value()
         self.params_plots.bottom_top_margin_fraction = self.spin_bottom_top_margin_fraction.value()


### PR DESCRIPTION
Channel and RGB widgets used a ```parent``` argument to recover or set some values in the plugin interface. This makes the code difficult to understand and debug. This PR removes this argument in favour of explicitly passing necessary arguments such as ```imchannels```. 