### PR TITLE
Dask

### DIFF
--- a/src/napari_sediment/_reader.py
+++ b/src/napari_sediment/_reader.py
@@ -130,8 +130,11 @@ def read_spectral(path, bands=None, row_bounds=None, col_bounds=None):
         if col_bounds is None:
             col_bounds = (0, zarr_image.shape[2])
 
-        data = zarr_image.get_orthogonal_selection(
-            (bands, slice(row_bounds[0], row_bounds[1]), slice(col_bounds[0],col_bounds[1])))
+        #data = zarr_image.get_orthogonal_selection(
+        #    (bands, slice(row_bounds[0], row_bounds[1]), slice(col_bounds[0],col_bounds[1])))
+        import dask.array as da
+        zarr_image = da.from_zarr(path)
+        data = zarr_image[bands, row_bounds[0]:row_bounds[1], col_bounds[0]:col_bounds[1]]
             
         data = np.moveaxis(data, 0, 2)
         

--- a/src/napari_sediment/batch_widget.py
+++ b/src/napari_sediment/batch_widget.py
@@ -178,7 +178,8 @@ class BatchWidget(QWidget):
                             imagechannels=imagechannels)
                 
                     self.rgb_ch, self.rgb_names = imagechannels.get_indices_of_bands(self.params_plots.rgb_bands)
-                    self.rgb_cube = imagechannels.get_image_cube(self.rgb_ch)
+                    self.rgb_cube = np.asarray(imagechannels.get_image_cube(self.rgb_ch))
+                    index_data = np.asarray(index_data)
 
                     self.export_rgb_image_scaled(f'{f.name}_{spectral_name}')
 
@@ -197,17 +198,18 @@ class BatchWidget(QWidget):
                         dpi=100)#, bbox_inches="tight")
                     
     def export_rgb_image_scaled(self, image_name):
-
-        limits = [[np.percentile(x, 2), np.percentile(x,98)] for x in self.rgb_cube]
-        microim = microshow(self.rgb_cube, cmaps=['pure_red', 'pure_green', 'pure_blue'], limits=limits)
+        
+        data = np.asarray(self.rgb_cube)
+        limits = [[np.percentile(x, 2), np.percentile(x,98)] for x in data]
+        microim = microshow(data, cmaps=['pure_red', 'pure_green', 'pure_blue'], limits=limits)
         microim.savefig(self.export_folder.joinpath(f'{image_name}_rgb.png'),dpi=300)
         
-        im_sqrt = np.sqrt(self.rgb_cube)
+        im_sqrt = np.sqrt(data)
         limits = [[np.percentile(x, 2), np.percentile(x,98)] for x in im_sqrt]
         microim = microshow(im_sqrt, cmaps=['pure_red', 'pure_green', 'pure_blue'], limits=limits)
         microim.savefig(self.export_folder.joinpath(f'{image_name}_rgb_qrt.png'),dpi=300)
 
-        im_log = np.log(self.rgb_cube)
+        im_log = np.log(data)
         limits = [[np.percentile(x, 2), np.percentile(x,98)] for x in im_log]
         microim = microshow(im_log, cmaps=['pure_red', 'pure_green', 'pure_blue'], limits=limits)
         microim.savefig(self.export_folder.joinpath(f'{image_name}_rgb_log.png'),dpi=300)

--- a/src/napari_sediment/classifier.py
+++ b/src/napari_sediment/classifier.py
@@ -1,12 +1,4 @@
-from torchvision import models
-from torch import nn
-from collections import OrderedDict
-import torch
 import numpy as np
-import skimage
-import pandas as pd
-from sklearn.model_selection import train_test_split
-from sklearn.ensemble import RandomForestClassifier
 
 from napari_convpaint.conv_paint import ConvPaintWidget
 
@@ -16,8 +8,8 @@ class ConvPaintSpectralWidget(ConvPaintWidget):
     and some defaults like multi-channel image and RGB input are set. Also adds
     an ml-mask layer to the viewer."""
     
-    def __init__(self, viewer):
-        super().__init__(viewer)
+    def __init__(self, viewer, parent=None, project=False, third_party=True):
+        super().__init__(viewer, parent, project, third_party)
 
         self.viewer = viewer
         self.check_use_project.hide()
@@ -26,7 +18,19 @@ class ConvPaintSpectralWidget(ConvPaintWidget):
         self.tabs.setTabVisible(1, False)
 
         self.prediction_btn.clicked.connect(self.update_ml_mask)
+        
+        self.add_connections_local()
 
+    def add_connections_local(self):
+        
+        self.select_layer_widget.changed.connect(self.default_to_multi_channel)
+
+    def default_to_multi_channel(self, event=None):
+
+        if self.select_layer_widget.value.ndim == 3:
+            
+            self.radio_multi_channel.setChecked(True)
+        
     def update_ml_mask(self, event):
         """Add ml-mask layer to viewer when segmenting"""
         

--- a/src/napari_sediment/hyperanalysis_widget.py
+++ b/src/napari_sediment/hyperanalysis_widget.py
@@ -404,7 +404,7 @@ class HyperAnalysisWidget(QWidget):
     def _compute_mnfr_bands(self):
         """Extract actual MNFR bands and plot them"""
 
-        data = np.moveaxis(self.viewer.layers['imcube'].data,0,2).astype(np.float32)
+        data = np.asarray(np.moveaxis(self.viewer.layers['imcube'].data,0,2), np.float32)
         self.image_mnfr = self.mnfr.reduce(data, num=data.shape[2])#, num=last_index)
 
         if 'mnfr' in self.viewer.layers:
@@ -504,10 +504,11 @@ class HyperAnalysisWidget(QWidget):
     def compute_end_members(self):
         """"Cluster the pure pixels and compute average end-members."""
 
-        pure = self.viewer.layers['pure'].data
+        pure = np.asarray(self.viewer.layers['pure'].data)
         # recover pixel vectors from denoised image and actual image
         vects = self.viewer.layers['denoised'].data[:, pure > self.ppi_threshold.value()]
-        vects_image = self.viewer.layers['imcube'].data[:,pure > self.ppi_threshold.value()] 
+        imcube_data = np.asarray(self.viewer.layers['imcube'].data)
+        vects_image = imcube_data[:,pure > self.ppi_threshold.value()] 
         
         # compute clustering
         labels = spectral_clustering(pixel_vectors=vects.T, dbscan_eps=self.qspin_endm_eps.value())

--- a/src/napari_sediment/hyperanalysis_widget.py
+++ b/src/napari_sediment/hyperanalysis_widget.py
@@ -378,8 +378,8 @@ class HyperAnalysisWidget(QWidget):
 
     def _on_click_mnfr(self):
         """Compute MNFR transform and compute vertical correlation. Keep all bands."""
-
-        data = np.moveaxis(self.viewer.layers['imcube'].data,0,2).astype(np.float32)
+        
+        data = np.asarray(np.moveaxis(self.viewer.layers['imcube'].data,0,2), np.float32)
         signal = calc_stats(
             image=data,
             mask=self.viewer.layers['mask'].data,

--- a/src/napari_sediment/imchannels.py
+++ b/src/napari_sediment/imchannels.py
@@ -139,17 +139,24 @@ class ImChannels:
             data = np.stack([self.channel_array[c] for c in channels], axis=0)
         else:
             full = [0, self.nrows, 0, self.ncols]
+            data = []
             for ind, r in enumerate(roi):
                 if r is None:
                     roi[ind] = full[ind]
-            data = np.zeros(
+            '''data = np.zeros(
                 shape=(len(channels), roi[1]-roi[0], roi[3]-roi[2]),
                 dtype=self.channel_array[channels[0]].dtype)
             for ind, c in enumerate(channels):
                 if self.rois[c] is None:
                     data[ind,:,:] = self.channel_array[c][roi[0]:roi[1], roi[2]:roi[3]]
                 else:
-                    data[ind,:,:] = self.channel_array[c]
+                    data[ind,:,:] = self.channel_array[c]'''
+            for ind, c in enumerate(channels):
+                if self.rois[c] is None:
+                    data.append(self.channel_array[c][roi[0]:roi[1], roi[2]:roi[3]])
+                else:
+                    data.append(self.channel_array[c])
+            data = np.stack(data, axis=0)
 
         return data
     

--- a/src/napari_sediment/sediment_widget.py
+++ b/src/napari_sediment/sediment_widget.py
@@ -333,6 +333,10 @@ class SedimentWidget(QWidget):
         self.mask_group_project.glayout.addWidget(self.btn_export)
         self.btn_import = QPushButton("Import Project")
         self.mask_group_project.glayout.addWidget(self.btn_import)
+        self.check_load_corrected = QCheckBox("Load corrected data")
+        self.check_load_corrected.setToolTip("Load corrected data instead of raw")
+        self.check_load_corrected.setChecked(False)
+        self.mask_group_project.glayout.addWidget(self.check_load_corrected)
 
         # io
         self.mask_group_export = VHGroup('Mas&k', orientation='G')
@@ -532,7 +536,15 @@ class SedimentWidget(QWidget):
         # reset acquisition index if new image is selected
         if image_name != self.current_image_name:
             self.current_image_name = image_name
-            self.imagechannels = ImChannels(self.imhdr_path)
+            #self.imagechannels = ImChannels(self.imhdr_path)
+            if self.check_load_corrected.isChecked():
+                if not self.export_folder.joinpath('corrected.zarr').exists():
+                    warnings.warn('Corrected image not found. Loading raw image instead.')
+                    self.imagechannels = ImChannels(self.imhdr_path)
+                else:
+                    self.imagechannels = ImChannels(self.export_folder.joinpath('corrected.zarr'))
+            else:
+                self.imagechannels = ImChannels(self.imhdr_path)
 
         self.crop_bounds['Min row'].setMaximum(self.imagechannels.nrows-1)
         self.crop_bounds['Max row'].setMaximum(self.imagechannels.nrows)
@@ -786,7 +798,9 @@ class SedimentWidget(QWidget):
             zarr_path=self.export_folder.joinpath('corrected.zarr'),
             band_indices=bands_to_correct,
             background_correction=self.check_batch_white.isChecked(),
-            destripe=self.check_batch_destripe.isChecked())
+            destripe=self.check_batch_destripe.isChecked(),
+            use_dask=True
+            )
 
 
     def get_summary_image_for_mask(self):
@@ -1083,6 +1097,7 @@ class SedimentWidget(QWidget):
         self.spinbox_metadata_scale.setValue(self.params.scale)
 
         # rois
+        self._add_roi_layer()
         mainroi = [np.array(x).reshape(4,2) for x in self.params.main_roi]
         if mainroi:
             mainroi[0] = mainroi[0].astype(int)

--- a/src/napari_sediment/sediment_widget.py
+++ b/src/napari_sediment/sediment_widget.py
@@ -35,6 +35,7 @@ from .spectralplot import SpectralPlotter
 from .widgets.channel_widget import ChannelWidget
 from .images import save_rgb_tiff_image
 from .widgets.rgb_widget import RGBWidget
+from .utils import update_contrast_on_layer
 
 import napari
 
@@ -731,6 +732,7 @@ class SedimentWidget(QWidget):
             
             for ind, c in enumerate(['red', 'green', 'blue']):
                 self.viewer.layers[c].data = im_corr[ind]
+                update_contrast_on_layer(self.viewer.layers[c])
                 self.viewer.layers[c].refresh()
 
 

--- a/src/napari_sediment/sediment_widget.py
+++ b/src/napari_sediment/sediment_widget.py
@@ -703,7 +703,7 @@ class SedimentWidget(QWidget):
         if selected_layer == 'imcube':
             channel_indices = self.qlist_channels.channel_indices
         elif selected_layer == 'RGB':
-            channel_indices = self.rgb_widget.rgb_ch
+            channel_indices = np.sort(self.rgb_widget.rgb_ch)
 
         col_bounds = (self.col_bounds if self.check_use_crop.isChecked() else None)
         white_data, dark_data, dark_for_white_data = load_white_dark(
@@ -726,11 +726,15 @@ class SedimentWidget(QWidget):
                 self.viewer.layers['imcube_corrected'].translate = (0, self.row_bounds[0], self.col_bounds[0])
 
         if (selected_layer == 'RGB') | (self.check_sync_bands_rgb.isChecked()):
+            sorted_rgb_indices = np.argsort(self.rgb_widget.rgb_ch)
+            rgb_sorted = np.asarray(['red', 'green', 'blue'])[sorted_rgb_indices]
+            rgb_sorted = [str(x) for x in rgb_sorted]
+
             im_corr = white_dark_correct(
-                np.stack([self.viewer.layers[x].data for x in ['red', 'green', 'blue']], axis=0), 
+                np.stack([self.viewer.layers[x].data for x in rgb_sorted], axis=0), 
                 white_data, dark_data, dark_for_white_data)
             
-            for ind, c in enumerate(['red', 'green', 'blue']):
+            for ind, c in enumerate(rgb_sorted):
                 self.viewer.layers[c].data = im_corr[ind]
                 update_contrast_on_layer(self.viewer.layers[c])
                 self.viewer.layers[c].refresh()

--- a/src/napari_sediment/spectral_indices_widget.py
+++ b/src/napari_sediment/spectral_indices_widget.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 from dataclasses import asdict
 import numpy as np
+import dask.array as da
 import matplotlib.pyplot as plt
 from qtpy.QtWidgets import (QVBoxLayout, QPushButton, QWidget,
                             QLabel, QFileDialog, QSpinBox,
@@ -574,6 +575,12 @@ class SpectralIndexWidget(QWidget):
             self._on_click_compute_index(event=None)
         toplot = self.viewer.layers[self.qcom_indices.currentText()].data
         toplot[toplot == np.inf] = 0
+
+        if isinstance(rgb_image[0], da.Array):
+            rgb_image = [x.compute() for x in rgb_image]
+        if isinstance(toplot, da.Array):
+            toplot = toplot.compute()
+
         format_dict = asdict(self.params_plots)
         _, self.ax1, self.ax2, self.ax3 = plot_spectral_profile(
             rgb_image=rgb_image, index_image=toplot, index_name=self.qcom_indices.currentText(),

--- a/src/napari_sediment/spectralindex.py
+++ b/src/napari_sediment/spectralindex.py
@@ -56,7 +56,7 @@ class SpectralIndex:
 
 
 def compute_index_RABD(left, trough, right, row_bounds, col_bounds, imagechannels):
-    """Compute the index RAB.
+    """Compute the index RABD.
     
     Parameters
     ----------
@@ -65,6 +65,13 @@ def compute_index_RABD(left, trough, right, row_bounds, col_bounds, imagechannel
     trough: float
         trough band
     right: float
+        right band
+    row_bounds: tuple of int
+        (row_start, row_end)
+    col_bounds: tuple of int
+        (col_start, col_end)
+    imagechannels: ImageChannels
+        image channels object
 
     Returns
     -------
@@ -97,7 +104,26 @@ def compute_index_RABD(left, trough, right, row_bounds, col_bounds, imagechannel
     return RABD
 
 def compute_index_RABA(left, right, row_bounds, col_bounds, imagechannels):
-    """Compute the index RAB."""
+    """Compute the index RABA.
+    
+    Parameters
+    ----------
+    left: float
+        left band
+    right: float
+        right band
+    row_bounds: tuple of int
+        (row_start, row_end)
+    col_bounds: tuple of int
+        (col_start, col_end)
+    imagechannels: ImageChannels
+        image channels object
+
+    Returns
+    -------
+    RABA: float
+        RABA index
+    """
 
     ltr = [left, right]
     # find band indices in the complete dataset
@@ -118,7 +144,26 @@ def compute_index_RABA(left, right, row_bounds, col_bounds, imagechannels):
     return RABA_array
     
 def compute_index_ratio(left, right, row_bounds, col_bounds, imagechannels):
+    """Compute the index ratio.
+        
+    Parameters
+    ----------
+    left: float
+        left band
+    right: float
+        right band
+    row_bounds: tuple of int
+        (row_start, row_end)
+    col_bounds: tuple of int
+        (col_start, col_end)
+    imagechannels: ImageChannels
+        image channels object
 
+    Returns
+    -------
+    ratio: float
+        ratio index
+    """
     ltr = [left, right]
     # find band indices in the complete dataset
     ltr_stack_indices = [find_index_of_band(imagechannels.centers, x) for x in ltr]

--- a/src/napari_sediment/spectralindex.py
+++ b/src/napari_sediment/spectralindex.py
@@ -135,11 +135,14 @@ def compute_index_RABA(left, right, row_bounds, col_bounds, imagechannels):
     R0_RN_cube = R0_RN_cube.astype(np.float32)
     num_bands = ltr_stack_indices[1] - ltr_stack_indices[0]
     line = (R0_RN_cube[1] - R0_RN_cube[0])/num_bands
-    RABA_array = np.zeros((row_bounds[1]-row_bounds[0], col_bounds[1]-col_bounds[0]))
+    RABA_array = None
     for i in range(num_bands):
         Ri = imagechannels.get_image_cube(channels=[ltr_stack_indices[0]+i], roi=roi)
         Ri = Ri.astype(np.float32)
-        RABA_array += ((R0_RN_cube[0] + i*line) / Ri[0] ) - 1
+        if RABA_array is None:
+            RABA_array = ((R0_RN_cube[0] + i*line) / Ri[0] ) - 1
+        else:
+            RABA_array += ((R0_RN_cube[0] + i*line) / Ri[0] ) - 1
 
     return RABA_array
     

--- a/src/napari_sediment/utils.py
+++ b/src/napari_sediment/utils.py
@@ -1,0 +1,12 @@
+import dask.array as da
+import numpy as np
+
+
+def update_contrast_on_layer(napari_layer):
+
+    if isinstance(napari_layer.data, da.Array):
+        napari_layer.contrast_limits_range = (napari_layer.data.min().compute(), napari_layer.data.max().compute())
+        napari_layer.contrast_limits = np.percentile(napari_layer.data.compute(), (2,98))
+    else:       
+        napari_layer.contrast_limits_range = (napari_layer.data.min(), napari_layer.data.max())
+        napari_layer.contrast_limits = np.percentile(napari_layer.data, (2,98))

--- a/src/napari_sediment/utils.py
+++ b/src/napari_sediment/utils.py
@@ -1,12 +1,9 @@
-import dask.array as da
 import numpy as np
 
 
 def update_contrast_on_layer(napari_layer):
 
-    if isinstance(napari_layer.data, da.Array):
-        napari_layer.contrast_limits_range = (napari_layer.data.min().compute(), napari_layer.data.max().compute())
-        napari_layer.contrast_limits = np.percentile(napari_layer.data.compute(), (2,98))
-    else:       
-        napari_layer.contrast_limits_range = (napari_layer.data.min(), napari_layer.data.max())
-        napari_layer.contrast_limits = np.percentile(napari_layer.data, (2,98))
+    data = np.asarray(napari_layer.data)
+          
+    napari_layer.contrast_limits_range = (data.min(), data.max())
+    napari_layer.contrast_limits = np.percentile(data, (2,98))

--- a/src/napari_sediment/widgets/rgb_widget.py
+++ b/src/napari_sediment/widgets/rgb_widget.py
@@ -8,9 +8,7 @@ from napari_guitils.gui_structures import VHGroup, TabSet
 from superqt import QDoubleRangeSlider
 
 from ..sediproc import find_index_of_band
-
-
-
+from ..utils import update_contrast_on_layer
 class RGBWidget(QWidget):
     """Widget to handle channel selection and display. Works only i parent widget
     has:
@@ -166,10 +164,4 @@ class RGBWidget(QWidget):
             else:
                 self.viewer.layers[cmap].data = rgb_cube[ind]
             
-            if isinstance(self.viewer.layers['red'].data, da.Array):
-                self.viewer.layers[cmap].contrast_limits_range = (self.viewer.layers[cmap].data.min().compute(), self.viewer.layers[cmap].data.max().compute())
-                self.viewer.layers[cmap].contrast_limits = np.percentile(self.viewer.layers[cmap].data.compute(), (2,98))
-            else:       
-                self.viewer.layers[cmap].contrast_limits_range = (self.viewer.layers[cmap].data.min(), self.viewer.layers[cmap].data.max())
-                self.viewer.layers[cmap].contrast_limits = np.percentile(self.viewer.layers[cmap].data, (2,98))
-            
+            update_contrast_on_layer(self.viewer.layers[cmap])

--- a/src/napari_sediment/widgets/rgb_widget.py
+++ b/src/napari_sediment/widgets/rgb_widget.py
@@ -7,8 +7,8 @@ import dask.array as da
 from napari_guitils.gui_structures import VHGroup, TabSet
 from superqt import QDoubleRangeSlider
 
-from ..sediproc import find_index_of_band
 from ..utils import update_contrast_on_layer
+
 class RGBWidget(QWidget):
     """Widget to handle channel selection and display. Works only i parent widget
     has:

--- a/src/napari_sediment/widgets/rgb_widget.py
+++ b/src/napari_sediment/widgets/rgb_widget.py
@@ -3,6 +3,7 @@ from qtpy.QtWidgets import (QComboBox, QPushButton, QWidget,
                             QCheckBox, QLineEdit, QSpinBox, QDoubleSpinBox,)
 from qtpy.QtCore import Qt
 import numpy as np
+import dask.array as da
 from napari_guitils.gui_structures import VHGroup, TabSet
 from superqt import QDoubleRangeSlider
 
@@ -165,6 +166,10 @@ class RGBWidget(QWidget):
             else:
                 self.viewer.layers[cmap].data = rgb_cube[ind]
             
-            self.viewer.layers[cmap].contrast_limits_range = (self.viewer.layers[cmap].data.min(), self.viewer.layers[cmap].data.max())
-            self.viewer.layers[cmap].contrast_limits = np.percentile(self.viewer.layers[cmap].data, (2,98))
+            if isinstance(self.viewer.layers['red'].data, da.Array):
+                self.viewer.layers[cmap].contrast_limits_range = (self.viewer.layers[cmap].data.min().compute(), self.viewer.layers[cmap].data.max().compute())
+                self.viewer.layers[cmap].contrast_limits = np.percentile(self.viewer.layers[cmap].data.compute(), (2,98))
+            else:       
+                self.viewer.layers[cmap].contrast_limits_range = (self.viewer.layers[cmap].data.min(), self.viewer.layers[cmap].data.max())
+                self.viewer.layers[cmap].contrast_limits = np.percentile(self.viewer.layers[cmap].data, (2,98))
             

--- a/src/napari_sediment/widgets/rgb_widget.py
+++ b/src/napari_sediment/widgets/rgb_widget.py
@@ -3,7 +3,6 @@ from qtpy.QtWidgets import (QComboBox, QPushButton, QWidget,
                             QCheckBox, QLineEdit, QSpinBox, QDoubleSpinBox,)
 from qtpy.QtCore import Qt
 import numpy as np
-import dask.array as da
 from napari_guitils.gui_structures import VHGroup, TabSet
 from superqt import QDoubleRangeSlider
 


### PR DESCRIPTION
- Use dask for most processing, in particular indices. This will allow to use parallel computing for most operations. This means that zarr files are not opened using the zarr library but with ```da.from_zarr``` 
- corrected data can now be imported (as dask array) in the pre-processing widget. As background correction will in the future be done as batch, this will allow to import the corrected data when masking, selecting rois etc.
- A major bug mixing the order of RGB channels in the ```imcube``` is now fixed