### PR TITLE
Roi first

### DIFF
--- a/src/napari_sediment/hyperanalysis_widget.py
+++ b/src/napari_sediment/hyperanalysis_widget.py
@@ -393,7 +393,12 @@ class HyperAnalysisWidget(QWidget):
     def _on_click_load_mask(self):
         """Load mask from file"""
         
-        mask = load_mask(get_mask_path(self.export_folder))[self.row_bounds[0]:self.row_bounds[1], self.col_bounds[0]:self.col_bounds[1]]
+        main_roi_row_min = self.mainroi[0][:,0].min()
+        main_roi_col_min = self.mainroi[0][:,1].min()
+        mask = load_mask(get_mask_path(self.export_folder))#[self.row_bounds[0]:self.row_bounds[1], self.col_bounds[0]:self.col_bounds[1]]
+        mask = mask[self.row_bounds[0]-main_roi_row_min:self.row_bounds[1]-main_roi_row_min,
+                    self.col_bounds[0]-main_roi_col_min:self.col_bounds[1]-main_roi_col_min]
+
         if 'mask' in self.viewer.layers:
             self.viewer.layers['mask'].data = mask
         else:

--- a/src/napari_sediment/imchannels.py
+++ b/src/napari_sediment/imchannels.py
@@ -81,9 +81,10 @@ class ImChannels:
                 else:
                     channels_full_image.append(channel)
             else:
+                # if a new roi is provided, reload the channel even if full frame is already loaded
                 if self.rois[channel] is None:
-                    if self.channel_array[channel] is None:
-                        channels_partial_image.append(channel)
+                    #if self.channel_array[channel] is None:
+                    channels_partial_image.append(channel)
                 else:
                     if not np.array_equal(roi, self.rois[channel]):
                         channels_partial_image.append(channel)

--- a/src/napari_sediment/spectral_indices_widget.py
+++ b/src/napari_sediment/spectral_indices_widget.py
@@ -161,7 +161,7 @@ class SpectralIndexWidget(QWidget):
         self.button_zoom_out.clicked.connect(self.on_zoom_out)
         
         self.spin_preview_dpi = QSpinBox()
-        self.spin_preview_dpi.setRange(100, 1000)
+        self.spin_preview_dpi.setRange(10, 1000)
         self.spin_preview_dpi.setValue(100)
         self.spin_preview_dpi.setSingleStep(1)
 
@@ -182,9 +182,9 @@ class SpectralIndexWidget(QWidget):
         self.index_plot_live.figure.set_layout_engine('none')
         #self.tabs.add_named_tab('Plotslive', self.index_plot_live)
 
-        self.tabs.add_named_tab('P&lots', self.scrollArea, grid_pos=(0, 0, 1, 2))
+        #self.tabs.add_named_tab('P&lots', self.scrollArea, grid_pos=(0, 0, 1, 2))
         self.scrollArea.setWidgetResizable(True)
-        self.scrollArea.setFixedHeight(200)
+        #self.scrollArea.setFixedHeight(200)
 
         self.tabs.add_named_tab('P&lots', self.button_zoom_in, grid_pos=(14, 0, 1, 1))
         self.tabs.add_named_tab('P&lots', self.button_zoom_out, grid_pos=(14, 1, 1, 1))
@@ -192,7 +192,7 @@ class SpectralIndexWidget(QWidget):
         self.tabs.add_named_tab('P&lots', self.spin_preview_dpi, grid_pos=(15, 1, 1, 1))
         self.tabs.add_named_tab('P&lots', QLabel('Final DPI'), grid_pos=(16, 0, 1, 1))
         self.tabs.add_named_tab('P&lots', self.spin_final_dpi, grid_pos=(16, 1, 1, 1))
-        
+
         self.btn_create_index_plot = QPushButton("Create index plot")
         self.tabs.add_named_tab('P&lots', self.btn_create_index_plot, grid_pos=(1, 0, 1, 2))
         self.spin_left_right_margin_fraction = QDoubleSpinBox()
@@ -611,6 +611,7 @@ class SpectralIndexWidget(QWidget):
         toplot[toplot == np.inf] = 0
         percentiles = np.percentile(toplot, [1, 99])
         toplot = np.clip(toplot, percentiles[0], percentiles[1])
+        mask = self.viewer.layers['mask'].data
 
         if isinstance(rgb_image[0], da.Array):
             rgb_image = [x.compute() for x in rgb_image]
@@ -619,7 +620,7 @@ class SpectralIndexWidget(QWidget):
 
         format_dict = asdict(self.params_plots)
         _, self.ax1, self.ax2, self.ax3 = plot_spectral_profile(
-            rgb_image=rgb_image, index_image=toplot, index_name=self.qcom_indices.currentText(),
+            rgb_image=rgb_image, mask=mask, index_image=toplot, index_name=self.qcom_indices.currentText(),
                                 format_dict=format_dict, scale=self.params.scale,
                                 location=self.params.location, fig=self.index_plot_live.figure, 
                                 roi=self.viewer.layers['rois'].data[0])
@@ -636,7 +637,8 @@ class SpectralIndexWidget(QWidget):
         self.pixmap = QPixmap(self.export_folder.joinpath('temp.png').as_posix())
         #self.pixlabel.setPixmap(self.pixmap.scaled(self.pixlabel.size().width(), self.pixlabel.size().height(), Qt.KeepAspectRatio))
         self.pixlabel.setPixmap(self.pixmap.scaled(self.pix_width, self.pix_height, Qt.KeepAspectRatio))
-
+        #self.pixlabel.show()
+        self.scrollArea.show()
         '''if self.pixlabel.size().height() < self.pixlabel.size().width():
             self.pixlabel.setPixmap(self.pixmap.scaledToWidth(self.pixlabel.size().width()))
         else:

--- a/src/napari_sediment/spectral_indices_widget.py
+++ b/src/napari_sediment/spectral_indices_widget.py
@@ -453,7 +453,7 @@ class SpectralIndexWidget(QWidget):
     def _on_click_load_mask(self):
         """Load mask from file"""
         
-        mask = load_mask(get_mask_path(self.export_folder))[self.row_bounds[0]:self.row_bounds[1], self.col_bounds[0]:self.col_bounds[1]]
+        mask = load_mask(get_mask_path(self.export_folder))#[self.row_bounds[0]:self.row_bounds[1], self.col_bounds[0]:self.col_bounds[1]]
         if 'mask' in self.viewer.layers:
             self.viewer.layers['mask'].data = mask
         else:

--- a/src/napari_sediment/spectralplot.py
+++ b/src/napari_sediment/spectralplot.py
@@ -6,7 +6,7 @@ from napari.utils import colormaps
 from microfilm import colorify
 from matplotlib_scalebar.scalebar import ScaleBar
 
-def plot_spectral_profile(rgb_image, index_image, index_name, format_dict, scale=1,
+def plot_spectral_profile(rgb_image, mask, index_image, index_name, format_dict, scale=1,
                           location="", fig=None, roi=None):
 
 
@@ -79,6 +79,7 @@ def plot_spectral_profile(rgb_image, index_image, index_name, format_dict, scale
     ax1.imshow(rgb_to_plot, aspect='auto')
     vmin = np.percentile(index_image, 0.1)
     vmax = np.percentile(index_image, 99.9)
+    index_image[mask==1] = np.nan
     #ax2.imshow(index_image, vmin=vmin, vmax=vmax, aspect='auto', cmap=mpl_map)
     ax2.imshow(index_image, aspect='auto', cmap=mpl_map)
     scalebar = ScaleBar(scale, "mm", 
@@ -102,7 +103,7 @@ def plot_spectral_profile(rgb_image, index_image, index_name, format_dict, scale
         colmin = 0
         colmax = index_image.shape[1]
     
-    proj = index_image[:,colmin:colmax].mean(axis=1)
+    proj = np.nanmean(index_image[:,colmin:colmax],axis=1)
     ax3.plot(proj, np.arange(len(proj)),
                 color=np.array(color_plotline),
                 linewidth=plot_thickness)

--- a/src/napari_sediment/widgets/rgb_widget.py
+++ b/src/napari_sediment/widgets/rgb_widget.py
@@ -167,5 +167,6 @@ class RGBWidget(QWidget):
                     blending='additive')
             else:
                 self.viewer.layers[cmap].data = rgb_cube[ind]
+                self.viewer.layers[cmap].translate = (self.row_bounds[0], self.col_bounds[0])
             
             update_contrast_on_layer(self.viewer.layers[cmap])


### PR DESCRIPTION
This PR implements the "roi first" approach. Now the users first manually selects a main roi and then crops the data with that roi. Further steps such as masking are then only done on this cropped region. The first step of background correction remains done as a very first step in order to keep a full version of corrected data. This solves in particular the request from issue #25.