### PR TITLE
use plain matplotlib

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -39,7 +39,7 @@ install_requires =
     superqt
     natsort
     spectral
-    napari-matplotlib
+    matplotlib
     scikit-image
     scikit-learn
     PyYAML

--- a/src/napari_sediment/utilities/sediproc.py
+++ b/src/napari_sediment/utilities/sediproc.py
@@ -526,7 +526,7 @@ def correct_save_to_zarr(imhdr_path, white_file_path, dark_for_im_file_path,
         'wavelength': list(np.array(img.metadata['wavelength'])[band_indices]),
         'centers': list(np.array(img.bands.centers)[band_indices])
         }
-
+    
     if use_dask:
         client.close()
 

--- a/src/napari_sediment/widget_utilities/spectralplotter.py
+++ b/src/napari_sediment/widget_utilities/spectralplotter.py
@@ -1,7 +1,9 @@
-from napari_matplotlib.base import NapariMPLWidget
+#from napari_matplotlib.base import NapariMPLWidget
 import numpy as np
+from matplotlib.backends.backend_qtagg import FigureCanvasQTAgg, NavigationToolbar2QT
+from qtpy.QtWidgets import QWidget, QVBoxLayout
 
-class SpectralPlotter(NapariMPLWidget):
+class SpectralPlotter(QWidget):
     """Subclass of napari_matplotlib NapariMPLWidget for voxel position based time series plotting.
     This widget contains a matplotlib figure canvas for plot visualisation and the matplotlib toolbar for easy option
     controls. The widget is not meant for direct docking to the napari viewer.
@@ -13,16 +15,20 @@ class SpectralPlotter(NapariMPLWidget):
         selector : napari_time_series_plotter.LayerSelector
         cursor_pos : tuple of current mouse cursor position in the napari viewer
     """
-    def __init__(self, napari_viewer, options=None):
-        super().__init__(napari_viewer)
+    def __init__(self, napari_viewer, options=None, tight_layout=True):
+        super().__init__()
+
+        self.canvas = FigureCanvasQTAgg()
+        self.canvas.figure.set_tight_layout(tight_layout)
+
+        self.toolbar = NavigationToolbar2QT(self.canvas, self)
+        
         self.axes = self.canvas.figure.subplots()
         self.cursor_pos = np.array([])
-        self.axes.tick_params(colors='white')
+        self.axes.tick_params(colors='black')
        
 
-    def clear(self):
-        """
-        Clear the canvas.
-        """
-        #self.axes.clear()
-        pass
+        self.setLayout(QVBoxLayout())
+        #self.layout().addWidget(self.toolbar)
+        self.layout().addWidget(self.canvas)
+        self.layout().addWidget(self.toolbar)

--- a/src/napari_sediment/widgets/hyperanalysis_widget.py
+++ b/src/napari_sediment/widgets/hyperanalysis_widget.py
@@ -415,6 +415,7 @@ class HyperAnalysisWidget(QWidget):
         for name in ['mnf', 'denoised']:
             if export_path.joinpath(f'{name}.zarr').is_dir():
                 im = np.array(zarr.open_array(export_path.joinpath(f'{name}.zarr')))
+                self.image_mnfr = np.moveaxis(im, 0, 2)
                 self.viewer.add_image(im, name=name)
         
         if export_path.joinpath('pure.zarr').is_dir():
@@ -441,10 +442,10 @@ class HyperAnalysisWidget(QWidget):
         
         export_path = Path(self.export_folder).joinpath(f'roi_{self.spin_selected_roi.value()}') 
         if export_path.joinpath('eigenvalues.csv').is_file():
-            self.eigenvals = pd.read_csv(export_path.joinpath('eigenvalues.csv')).values
+            self.eigenvals = pd.read_csv(export_path.joinpath('eigenvalues.csv')).eigenvalues.values
             self.plot_eigenvals()
         if export_path.joinpath('correlation.csv').is_file():
-            self.all_coef = pd.read_csv(export_path.joinpath('correlation.csv')).values
+            self.all_coef = pd.read_csv(export_path.joinpath('correlation.csv')).correlation.values
             self.plot_correlation()
         if export_path.joinpath('end_members.csv').is_file():
             self.end_members = pd.read_csv(export_path.joinpath('end_members.csv')).values
@@ -506,7 +507,7 @@ class HyperAnalysisWidget(QWidget):
 
         self.eigen_plot.axes.clear()
         self.eigen_plot.axes.plot(self.eigenvals)
-        self.eigen_plot.axes.set_title('Eigenvalues', fontdict={'color':'w'})
+        self.eigen_plot.axes.set_title('Eigenvalues', fontdict={'color':'black'})
             
         self.eigen_plot.canvas.figure.canvas.draw()
 
@@ -548,8 +549,9 @@ class HyperAnalysisWidget(QWidget):
 
         self.corr_plot.axes.clear()
         self.corr_plot.axes.plot(self.all_coef)#, linewidth=0.1, markersize=0.5)
-        self.corr_plot.axes.set_title('Line correlation', fontdict={'color':'w'})
+        self.corr_plot.axes.set_title('Line correlation', fontdict={'color':'black'})
         self.corr_plot.canvas.figure.canvas.draw()
+        
 
     def _on_click_reduce_mnfr_on_correlation(self):
         """Select bands based on correlation between lines. As a general rule, keep
@@ -673,7 +675,7 @@ class HyperAnalysisWidget(QWidget):
         self.ppi_plot.axes.set_xlabel('Wavelength', color='black')
         self.ppi_plot.axes.set_ylabel('Continuum removed', color='black')
         self.ppi_plot.axes.tick_params(axis='both', colors='black')
-        self.ppi_plot.figure.patch.set_facecolor('white')
+        self.ppi_plot.canvas.figure.patch.set_facecolor('white')
         self.ppi_plot.canvas.figure.canvas.draw()
 
 
@@ -707,8 +709,8 @@ class HyperAnalysisWidget(QWidget):
             return
 
         self.scan_plot.axes.clear()
-        self.scan_plot.axes.set_xlabel('Wavelength (nm)', color='white')
-        self.scan_plot.axes.set_ylabel('Intensity', color='white')
+        self.scan_plot.axes.set_xlabel('Wavelength (nm)', color='black')
+        self.scan_plot.axes.set_ylabel('Intensity', color='black')
 
         spectral_pixel = np.array(self.spectral_pixel, dtype=np.float64)
         

--- a/src/napari_sediment/widgets/sediment_widget.py
+++ b/src/napari_sediment/widgets/sediment_widget.py
@@ -528,8 +528,8 @@ class SedimentWidget(QWidget):
 
         # SpectralPlotter
         self.scan_plot = SpectralPlotter(napari_viewer=self.viewer)
-        self.scan_plot.axes.set_xlabel('Wavelength (nm)', color='white')
-        self.scan_plot.axes.set_ylabel('Intensity', color='white')
+        self.scan_plot.axes.set_xlabel('Wavelength (nm)', color='black')
+        self.scan_plot.axes.set_ylabel('Intensity', color='black')
         self.tabs.add_named_tab('P&lotting', self.scan_plot, (0,0,1,2))
 
         # Checkbox "Remove continuum"
@@ -1273,8 +1273,8 @@ class SedimentWidget(QWidget):
             return
 
         self.scan_plot.axes.clear()
-        self.scan_plot.axes.set_xlabel('Wavelength (nm)', color='white')
-        self.scan_plot.axes.set_ylabel('Intensity', color='white')
+        self.scan_plot.axes.set_xlabel('Wavelength (nm)', color='black')
+        self.scan_plot.axes.set_ylabel('Intensity', color='black')
 
         spectral_pixel = np.array(self.spectral_pixel, dtype=np.float64)
         

--- a/src/napari_sediment/widgets/spectral_indices_widget.py
+++ b/src/napari_sediment/widgets/spectral_indices_widget.py
@@ -17,7 +17,7 @@ from magicgui.widgets import FileEdit
 
 from napari.utils import progress
 import pandas as pd
-from napari_matplotlib.base import NapariMPLWidget
+#from napari_matplotlib.base import NapariMPLWidget
 from napari_guitils.gui_structures import TabSet, VHGroup
 
 from ..data_structures.parameters import Param
@@ -245,8 +245,8 @@ class SpectralIndexWidget(QWidget):
         self.scrollArea = QScrollArea()
         self.scrollArea.setWidget(self.pixlabel)
 
-        self.index_plot_live = NapariMPLWidget(napari_viewer=self.viewer)
-        self.index_plot_live.figure.set_layout_engine('none')
+        self.index_plot_live = SpectralPlotter(napari_viewer=self.viewer)
+        self.index_plot_live.canvas.figure.set_layout_engine('none')
 
         self.scrollArea.setWidgetResizable(True)
 
@@ -747,13 +747,13 @@ class SpectralIndexWidget(QWidget):
         ax_histx.imshow(out, extent=(self.endmember_bands.min(),self.endmember_bands.max(), 0,10))
         ax_histx.set_axis_off()
 
-        self.em_plot.axes.set_xlabel('Wavelength', color='white')
-        self.em_plot.axes.set_ylabel('Continuum removed', color='white')
+        self.em_plot.axes.set_xlabel('Wavelength', color='black')
+        self.em_plot.axes.set_ylabel('Continuum removed', color='black')
         self.em_plot.axes.xaxis.label.set_color('black')
         self.em_plot.axes.yaxis.label.set_color('black')
         self.em_plot.axes.tick_params(axis='both', colors='black')
-        self.em_plot.figure.patch.set_facecolor('white')
-        self.em_plot.figure.canvas.draw()
+        self.em_plot.canvas.figure.patch.set_facecolor('white')
+        self.em_plot.canvas.figure.canvas.draw()
 
     def save_endmembers_plot(self):
         """
@@ -767,12 +767,12 @@ class SpectralIndexWidget(QWidget):
             num_lines = len(self.em_boundary_lines)
             for i in range(num_lines):
                 self.em_boundary_lines[i].set_color([0,0,0,0])
-        self.em_plot.figure.canvas.draw()
-        self.em_plot.figure.savefig(export_folder.joinpath('endmembers.png'), dpi=300)
+        self.em_plot.canvas.figure.canvas.draw()
+        self.em_plot.canvas.figure.savefig(export_folder.joinpath('endmembers.png'), dpi=300)
         if self.em_boundary_lines is not None:
             for i in range(num_lines):
                 self.em_boundary_lines[i].set_color([1,0,0])
-        self.em_plot.figure.canvas.draw()
+        self.em_plot.canvas.figure.canvas.draw()
 
     def _on_change_em_boundaries(self, event=None):
         """
@@ -829,7 +829,7 @@ class SpectralIndexWidget(QWidget):
             )
             except:
                 pass
-            self.em_plot.figure.canvas.draw()
+            self.em_plot.canvas.figure.canvas.draw()
         
         #self._connect_spin_bounds()
 
@@ -1081,11 +1081,11 @@ class SpectralIndexWidget(QWidget):
         _, self.ax1, self.ax2, self.ax3 = plot_spectral_profile(
             rgb_image=rgb_image, mask=mask, index_obj=self.index_collection[index_series[0].index_name],
             format_dict=format_dict, scale=self.params.scale, scale_unit=self.params.scale_units,
-            location=self.params.location, fig=self.index_plot_live.figure, 
+            location=self.params.location, fig=self.index_plot_live.canvas.figure, 
             roi=roi)
 
         # save temporary low-res figure for display in napari
-        self.index_plot_live.figure.savefig(
+        self.index_plot_live.canvas.figure.savefig(
             self.export_folder.joinpath('temp.png'),
             dpi=self.spin_preview_dpi.value())#, bbox_inches="tight")
 
@@ -1127,12 +1127,12 @@ class SpectralIndexWidget(QWidget):
             scale=self.params.scale,
             scale_unit=self.params.scale_units,
             location=self.params.location, 
-            fig=self.index_plot_live.figure,
+            fig=self.index_plot_live.canvas.figure,
             roi=roi)
         
         if show_plot:
             # save temporary low-res figure for display in napari
-            self.index_plot_live.figure.savefig(
+            self.index_plot_live.canvas.figure.savefig(
                 self.export_folder.joinpath('temp.png'),
                 dpi=self.spin_preview_dpi.value())#, bbox_inches="tight")
             
@@ -1179,10 +1179,10 @@ class SpectralIndexWidget(QWidget):
             _, self.ax1, self.ax2, self.ax3 = plot_spectral_profile(
                 rgb_image=rgb_image, mask=mask, index_obj=self.index_collection[i_s.index_name],
                 format_dict=format_dict, scale=self.params.scale, scale_unit=self.params.scale_units,
-                location=self.params.location, fig=self.index_plot_live.figure, 
+                location=self.params.location, fig=self.index_plot_live.canvas.figure, 
                 roi=roi)
 
-            self.index_plot_live.figure.savefig(
+            self.index_plot_live.canvas.figure.savefig(
                 export_folder.joinpath(f'{i_s.index_name}_index_plot.png'),
             dpi=self.spin_final_dpi.value())
 
@@ -1212,7 +1212,7 @@ class SpectralIndexWidget(QWidget):
             force_recompute = self.check_force_recompute.isChecked()
 
         self.create_multi_index_plot(event=None, show_plot=False, force_recompute=force_recompute)
-        self.index_plot_live.figure.savefig(
+        self.index_plot_live.canvas.figure.savefig(
                 self.plot_folder().joinpath(f'multi_index_plot.png'),
                 dpi=self.spin_final_dpi.value())
 
@@ -1227,9 +1227,9 @@ class SpectralIndexWidget(QWidget):
     def _on_click_reset_figure_size(self, event=None):
         """Reset figure size to default"""
 
-        self.index_plot_live.figure.set_size_inches(self.fig_size)
-        self.index_plot_live.figure.canvas.draw()
-        self.index_plot_live.figure.canvas.flush_events()
+        self.index_plot_live.canvas.set_size_inches(self.fig_size)
+        self.index_plot_live.canvas.figure.canvas.draw()
+        self.index_plot_live.canvas.figure.canvas.flush_events()
 
         vsize = self.viewer.window.geometry()
         self.viewer.window.resize(vsize[2]-10,vsize[3]-10)
@@ -1418,7 +1418,7 @@ class SpectralIndexWidget(QWidget):
         export_folder = self.plot_folder()
         if export_file is None:
             export_file = export_folder.joinpath(self.qcom_indices.currentText()+'_index_plot.png')
-        self.index_plot_live.figure.savefig(
+        self.index_plot_live.canvas.figure.savefig(
             fname=export_file, dpi=self.spin_final_dpi.value())#, bbox_inches="tight")
         self._on_export_index_projection()
 


### PR DESCRIPTION
napari-matplotlib is not really necessary for this plugin which only requires the ability to create interactive plots. As it is currently stuck to napari < 5 we remove this dependency here and ```SpectraPlotter``` object has been turned into a basic QWidget mimicking the ```BaseNapariMPLWidget```.

If in the future, if we need to revert to napari-matplotlib, this can easily be done by changing the base class to ```NapariMPLWidget```, as the syntax is conserved. The only necessary change is the color of labels which are now black, as the plots now default to white background.